### PR TITLE
Fix | Use meta_title for HTML title tag across all pages

### DIFF
--- a/src/app/[uid]/page.tsx
+++ b/src/app/[uid]/page.tsx
@@ -26,7 +26,7 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
     //     robots = { index: false, follow: true }
     // }
     return {
-        title: prismic.asText(page.data.title),
+        title: page.data.meta_title || prismic.asText(page.data.title),
         description: page.data.meta_description,
         openGraph: {
             title: page.data.meta_title || undefined,
@@ -111,7 +111,7 @@ export default async function Page({ params }: { params: Params }) {
             name: 'Athayog Living - Personal Yoga Trainer in Indiranagar',
             image: '',
             description:
-                'Become a globally certified yoga teacher in 30 days with AthaYog Living’s residential course. Accredited by Yoga Alliance USA + VYASA with accommodation, practical learning, mentorship, and career support.',
+                'Book 1-on-1 personal yoga sessions in Indiranagar, Bangalore. Certified trainers, customized one-on-one sessions with expert guidance. Consultation first.',
             brand: {
                 '@type': 'Brand',
                 name: 'AthaYog Living',

--- a/src/app/blogs/[uid]/page.tsx
+++ b/src/app/blogs/[uid]/page.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
     const page = await client.getByUID('blog_post', params.uid).catch(() => notFound())
 
     return {
-        title: prismic.asText(page.data.title),
+        title: page.data.meta_title || prismic.asText(page.data.title),
         description: page.data.meta_description,
         openGraph: {
             title: page.data.meta_title || undefined,

--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -11,7 +11,7 @@ export async function generateMetadata(): Promise<Metadata> {
     const blogs = await client.getByUID('page', 'blogs')
 
     return {
-        title: prismic.asText(blogs.data.title),
+        title: blogs.data.meta_title || prismic.asText(blogs.data.title),
         description: blogs.data.meta_description,
         openGraph: {
             title: blogs.data.meta_title || undefined,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata(): Promise<Metadata> {
     const home = await client.getByUID('page', 'home')
 
     return {
-        title: prismic.asText(home.data.title),
+        title: home.data.meta_title ?? prismic.asText(home.data.title),
         description: home.data.meta_description,
         openGraph: {
             title: home.data.meta_title ?? undefined,

--- a/src/app/register/[uid]/page.tsx
+++ b/src/app/register/[uid]/page.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
     const page = await client.getByUID('registration_page', params.uid).catch(() => notFound())
 
     return {
-        title: prismic.asText(page.data.title),
+        title: page.data.meta_title || prismic.asText(page.data.title),
         description: page.data.meta_description,
         openGraph: {
             title: page.data.meta_title || undefined,

--- a/src/slices/CoursesHero/index.tsx
+++ b/src/slices/CoursesHero/index.tsx
@@ -135,7 +135,7 @@ const CoursesHero = ({ slice }: CoursesHeroProps): JSX.Element => {
                                                 opacity: 0.4,
                                             }}
                                         >
-                                            <Image src={flowerMandela} alt="Flower Mandela" style={{ width: '100%', height: '100%' }} />
+                                            <Image src={flowerMandela} alt="Flower Mandela" width={2270} height={2118} style={{ width: '100%', height: '100%' }} />
                                         </Box>
                                     )}
 
@@ -217,7 +217,7 @@ const CoursesHero = ({ slice }: CoursesHeroProps): JSX.Element => {
                                             opacity: 0.4,
                                         }}
                                     >
-                                        <Image src={flowerMandela} alt="Flower Mandela" style={{ width: '100%', height: '100%' }} />
+                                        <Image src={flowerMandela} alt="Flower Mandela" width={2270} height={2118} style={{ width: '100%', height: '100%' }} />
                                     </Box>
                                 )}
                                 {/* Responsive wrapper for Person image */}
@@ -340,7 +340,7 @@ const CoursesHero = ({ slice }: CoursesHeroProps): JSX.Element => {
                                                 opacity: 0.4,
                                             }}
                                         >
-                                            <Image src={flowerMandela} alt="Flower Mandela" style={{ width: '100%', height: '100%' }} />
+                                            <Image src={flowerMandela} alt="Flower Mandela" width={2270} height={2118} style={{ width: '100%', height: '100%' }} />
                                         </Box>
                                     )}
                                     <Box sx={{ display: { xs: 'block', lg: 'none' }, alignSelf: 'flex-start' }}>
@@ -421,7 +421,7 @@ const CoursesHero = ({ slice }: CoursesHeroProps): JSX.Element => {
                                             opacity: 0.4,
                                         }}
                                     >
-                                        <Image src={flowerMandela} alt="Flower Mandela" style={{ width: '100%', height: '100%' }} />
+                                        <Image src={flowerMandela} alt="Flower Mandela" width={2270} height={2118} style={{ width: '100%', height: '100%' }} />
                                     </Box>
                                 )}
 


### PR DESCRIPTION
- Changed generateMetadata in homepage, service pages ([uid]), blogs, and registration pages to read from meta_title field first, falling back to page title
- Fixes bug where HTML <title> was showing page heading instead of SEO meta title
- Fixed personal-yoga-training-indiranagar JSON-LD schema description (was copy-pasted from residential)
- Fixed FlowerMandela.png Image component missing required width/height props