### PR TITLE
Perf: Lazy-load below-fold sections on LD landing pages via next/dynamic

### DIFF
--- a/src/app/ld/group-classes-indiranagar/page.tsx
+++ b/src/app/ld/group-classes-indiranagar/page.tsx
@@ -1,28 +1,30 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { Box } from '@mui/material'
-import FAQCTASection from '@/app/ld/FAQCTASection'
 import GroupsIcon from '@mui/icons-material/Groups'
 import SchoolIcon from '@mui/icons-material/School'
-import FeatureSection from '@/app/ld/FeatureSection'
 import WbSunnyIcon from '@mui/icons-material/WbSunny'
 import YogaProgramHero from '@/app/ld/YogaProgramHero'
 import ScheduleIcon from '@mui/icons-material/Schedule'
-import ComparisonSection from '@/app/ld/ComparisonSection'
 import LocationOnIcon from '@mui/icons-material/LocationOn'
 const BackgroundHeroImage = '/images/anatomy.jpg'
 import PsychologyIcon from '@mui/icons-material/Psychology'
 import WorkOutlineIcon from '@mui/icons-material/WorkOutlineOutlined'
-import ImageFeatureSection from '@/app/ld/ImageFeatureSection'
-import ClassOverviewSection from '@/app/ld/ClassOverviewSection'
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth'
 import DirectionsRunIcon from '@mui/icons-material/DirectionsRun'
 import ThumbUpOffAltIcon from '@mui/icons-material/ThumbUpOffAlt'
-import TestimonialCTASection from '@/app/ld/TestimonialCTASection'
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder'
 const GirlMeditattngImage = '/images/mental-health/2.png'
 import SelfImprovementIcon from '@mui/icons-material/SelfImprovement'
 import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutlined'
+
+const FeatureSection = dynamic(() => import('@/app/ld/FeatureSection'))
+const ClassOverviewSection = dynamic(() => import('@/app/ld/ClassOverviewSection'))
+const ComparisonSection = dynamic(() => import('@/app/ld/ComparisonSection'))
+const ImageFeatureSection = dynamic(() => import('@/app/ld/ImageFeatureSection'))
+const TestimonialCTASection = dynamic(() => import('@/app/ld/TestimonialCTASection'))
+const FAQCTASection = dynamic(() => import('@/app/ld/FAQCTASection'))
 
 export default function LandingPage() {
     return (

--- a/src/app/ld/personal-yoga-training-indiranagar/page.tsx
+++ b/src/app/ld/personal-yoga-training-indiranagar/page.tsx
@@ -1,17 +1,15 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { Box } from '@mui/material'
 import ChatIcon from '@mui/icons-material/Chat'
 import TuneIcon from '@mui/icons-material/Tune'
-import FAQCTASection from '@/app/ld/FAQCTASection'
 import PersonIcon from '@mui/icons-material/Person'
-import FeatureSection from '@/app/ld/FeatureSection'
 import HealingIcon from '@mui/icons-material/Healing'
 import YogaProgramHero from '@/app/ld/YogaProgramHero'
 import ScheduleIcon from '@mui/icons-material/Schedule'
 const Image1 = '/images/mental-health/1.png';
 const Image2 = '/images/mental-health/2.png';
-import BentoGridSection from '@/app/ld/BentoGridSection'
 import ComparisonSection from '@/app/ld/ComparisonSection'
 import PsychologyIcon from '@mui/icons-material/Psychology'
 import StraightenIcon from '@mui/icons-material/Straighten'
@@ -19,14 +17,18 @@ import TrendingUpIcon from '@mui/icons-material/TrendingUp'
 import VisibilityIcon from '@mui/icons-material/Visibility'
 const WhoChooseImage = '/images/Who_Chooses.png';
 import LayersClearIcon from '@mui/icons-material/LayersClear'
-import ImageFeatureSection from '@/app/ld/ImageFeatureSection'
-import NumberedListSection from '@/app/ld/NumberedListSection'
-import SplitContentSection from '@/app/ld/SplitContentSection'
 import TrackChangesIcon from '@mui/icons-material/TrackChanges'
-import TestimonialCTASection from '@/app/ld/TestimonialCTASection'
 import EventAvailableIcon from '@mui/icons-material/EventAvailable'
-import OptionsShowcaseSection from '@/app/ld/OptionsShowcaseSection'
 const BackgroundImageHero = '/images/landing-page-hero-2.jpg';
+
+const FeatureSection = dynamic(() => import('@/app/ld/FeatureSection'))
+const BentoGridSection = dynamic(() => import('@/app/ld/BentoGridSection'))
+const ImageFeatureSection = dynamic(() => import('@/app/ld/ImageFeatureSection'))
+const NumberedListSection = dynamic(() => import('@/app/ld/NumberedListSection'))
+const SplitContentSection = dynamic(() => import('@/app/ld/SplitContentSection'))
+const OptionsShowcaseSection = dynamic(() => import('@/app/ld/OptionsShowcaseSection'))
+const TestimonialCTASection = dynamic(() => import('@/app/ld/TestimonialCTASection'))
+const FAQCTASection = dynamic(() => import('@/app/ld/FAQCTASection'))
 
 export default function LandingPage() {
     return (

--- a/src/app/ld/residential-yoga-teacher-training/page.tsx
+++ b/src/app/ld/residential-yoga-teacher-training/page.tsx
@@ -1,31 +1,33 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { Box } from '@mui/material'
 import HomeIcon from '@mui/icons-material/Home'
 import ForumIcon from '@mui/icons-material/Forum'
 import GavelIcon from '@mui/icons-material/Gavel'
-import FAQCTASection from '@/app/ld/FAQCTASection'
 import RepeatIcon from '@mui/icons-material/Repeat'
-import FeatureSection from '@/app/ld/FeatureSection'
 import WbSunnyIcon from '@mui/icons-material/WbSunny'
 const MeditationImage = '/images/Medi.jpg';
-import IconListSection from '@/app/ld/IconListSection'
 import YogaProgramHero from '@/app/ld/YogaProgramHero'
 import ScheduleIcon from '@mui/icons-material/Schedule'
-import BentoGridSection from '@/app/ld/BentoGridSection'
 import DeviceHubIcon from '@mui/icons-material/DeviceHub'
 const PranayamaImage = '/images/pranayama.png';
 import NightlightIcon from '@mui/icons-material/Nightlight'
 const WhoChooseImage = '/images/Who_Chooses.png';
-import ImageFeatureSection from '@/app/ld/ImageFeatureSection'
-import NumberedListSection from '@/app/ld/NumberedListSection'
-import SplitContentSection from '@/app/ld/SplitContentSection'
 const ResidentialHeroImage = '/images/residential.jpg';
-import TestimonialCTASection from '@/app/ld/TestimonialCTASection'
 const ResidentialImage = '/images/residential-yoga.jpg';
 import DoNotDisturbOnIcon from '@mui/icons-material/DoNotDisturbOn'
 import SelfImprovementIcon from '@mui/icons-material/SelfImprovement'
 import SentimentVeryDissatisfiedIcon from '@mui/icons-material/SentimentVeryDissatisfied'
+
+const FeatureSection = dynamic(() => import('@/app/ld/FeatureSection'))
+const IconListSection = dynamic(() => import('@/app/ld/IconListSection'))
+const BentoGridSection = dynamic(() => import('@/app/ld/BentoGridSection'))
+const ImageFeatureSection = dynamic(() => import('@/app/ld/ImageFeatureSection'))
+const NumberedListSection = dynamic(() => import('@/app/ld/NumberedListSection'))
+const SplitContentSection = dynamic(() => import('@/app/ld/SplitContentSection'))
+const TestimonialCTASection = dynamic(() => import('@/app/ld/TestimonialCTASection'))
+const FAQCTASection = dynamic(() => import('@/app/ld/FAQCTASection'))
 
 export default function LandingPage() {
     return (

--- a/src/app/ld/yoga-teacher-training-ryt-200-non-residential/page.tsx
+++ b/src/app/ld/yoga-teacher-training-ryt-200-non-residential/page.tsx
@@ -1,10 +1,9 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { Box } from '@mui/material'
-import FAQCTASection from '@/app/ld/FAQCTASection'
 import GroupsIcon from '@mui/icons-material/Groups'
 import SchoolIcon from '@mui/icons-material/School'
-import FeatureSection from '@/app/ld/FeatureSection'
 import WbSunnyIcon from '@mui/icons-material/WbSunny'
 const AnatomyImage = '/images/anatomy.jpg'
 import YogaProgramHero from '@/app/ld/YogaProgramHero'
@@ -17,13 +16,16 @@ import RestartAltIcon from '@mui/icons-material/RestartAlt'
 import TrendingUpIcon from '@mui/icons-material/TrendingUp'
 import AccountTreeIcon from '@mui/icons-material/AccountTree'
 import WorkOutlineIcon from '@mui/icons-material/WorkOutlineOutlined'
-import ImageFeatureSection from '@/app/ld/ImageFeatureSection'
-import NumberedListSection from '@/app/ld/NumberedListSection'
-import SplitContentSection from '@/app/ld/SplitContentSection'
 import DirectionsRunIcon from '@mui/icons-material/DirectionsRun'
 const BackgroundHeroImage = '/images/certification.jpg'
-import TestimonialCTASection from '@/app/ld/TestimonialCTASection'
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder'
+
+const FeatureSection = dynamic(() => import('@/app/ld/FeatureSection'))
+const ImageFeatureSection = dynamic(() => import('@/app/ld/ImageFeatureSection'))
+const NumberedListSection = dynamic(() => import('@/app/ld/NumberedListSection'))
+const SplitContentSection = dynamic(() => import('@/app/ld/SplitContentSection'))
+const TestimonialCTASection = dynamic(() => import('@/app/ld/TestimonialCTASection'))
+const FAQCTASection = dynamic(() => import('@/app/ld/FAQCTASection'))
 
 export default function LandingPage() {
     return (

--- a/src/app/ld/yoga-ttc-online-certification/page.tsx
+++ b/src/app/ld/yoga-ttc-online-certification/page.tsx
@@ -1,16 +1,14 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { Box } from '@mui/material'
 import GavelIcon from '@mui/icons-material/Gavel'
-import FAQCTASection from '@/app/ld/FAQCTASection'
 const EhicsImage = '/images/ethics.jpg'
 import LiveTvIcon from '@mui/icons-material/LiveTv'
 import PublicIcon from '@mui/icons-material/Public'
 import SchoolIcon from '@mui/icons-material/School'
-import FeatureSection from '@/app/ld/FeatureSection'
 const AnatomyImage = '/images/anatomy.jpg'
 const MeditationImage = '/images/Medi.jpg'
-import IconListSection from '@/app/ld/IconListSection'
 import YogaProgramHero from '@/app/ld/YogaProgramHero'
 const TeachingImage = '/images/teaching.jpg'
 const FeedbackImage = '/images/feedback.jpg'
@@ -21,13 +19,17 @@ const WarrirorPose = '/images/warrior_pose.png'
 import AccessTimeIcon from '@mui/icons-material/AccessTime'
 import LocationOffIcon from '@mui/icons-material/LocationOff'
 import WorkOutlineIcon from '@mui/icons-material/WorkOutlineOutlined'
-import ImageFeatureSection from '@/app/ld/ImageFeatureSection'
-import NumberedListSection from '@/app/ld/NumberedListSection'
-import SplitContentSection from '@/app/ld/SplitContentSection'
 const heroImage = '/images/landing-page-hero-10.jpg'
-import LearningAreasSection from '@/app/ld/LearningAreasSection'
 const CertificationImage = '/images/certification.jpg'
-import TestimonialCTASection from '@/app/ld/TestimonialCTASection'
+
+const FeatureSection = dynamic(() => import('@/app/ld/FeatureSection'))
+const IconListSection = dynamic(() => import('@/app/ld/IconListSection'))
+const ImageFeatureSection = dynamic(() => import('@/app/ld/ImageFeatureSection'))
+const NumberedListSection = dynamic(() => import('@/app/ld/NumberedListSection'))
+const SplitContentSection = dynamic(() => import('@/app/ld/SplitContentSection'))
+const LearningAreasSection = dynamic(() => import('@/app/ld/LearningAreasSection'))
+const TestimonialCTASection = dynamic(() => import('@/app/ld/TestimonialCTASection'))
+const FAQCTASection = dynamic(() => import('@/app/ld/FAQCTASection'))
 import HealthAndSafetyIcon from '@mui/icons-material/HealthAndSafety'
 import SelfImprovementIcon from '@mui/icons-material/SelfImprovement'
 const GirlBreathignImage = '/images/landing-page-hero-11.jpg'


### PR DESCRIPTION
- Converted static imports to next/dynamic for all section components except YogaProgramHero (hero) on 5 LD pages
- Hero section (YogaProgramHero with contact form) loads immediately as critical path
- All other sections (FeatureSection, FAQ, testimonials, etc.) now code-split and lazy-load
- Reduces initial JS bundle size, improving LCP and TBT Core Web Vitals